### PR TITLE
Fix Illegal offset type exeption

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "notification"
     ],
     "require": {
-        "bolt/bolt": "^3.0"
+        "bolt/bolt": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7"

--- a/src/BoltSendEmailForNewContentExtension.php
+++ b/src/BoltSendEmailForNewContentExtension.php
@@ -64,7 +64,7 @@ class BoltSendEmailForNewContentExtension extends SimpleExtension
 
         if ($contentNewlyPublished) {
             // Launch the notification
-            $notify = new Notifications($app, $this->getConfig(), $record);
+            $notify = new Notifications($app, $this->getConfig(), $record, $contenttype);
 
             // Search subscribers
             try {

--- a/src/BoltSendEmailForNewContentExtension.php
+++ b/src/BoltSendEmailForNewContentExtension.php
@@ -176,6 +176,11 @@ class BoltSendEmailForNewContentExtension extends SimpleExtension
                 'emailsubject' => 'email_subject.twig'
             ],
 
+            'email' => [
+                'replyto_name'  => NULL,
+                'replyto_email' => NULL
+            ],
+
             'notifications' => [
                 'entries' => [
                     'enabled'     => true

--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -183,12 +183,16 @@ class Notifications
     {
         // Set the recipient for *this* message
         $emailTo = $recipient->get($this->emailField);
-        $message->setTo($emailTo);
 
-        if ($this->app['mailer']->send($message)) {
-            $this->app['logger.system']->info("Sent BoltSendEmailForNewContentExtension notification to {$emailTo}", ['event' => 'extensions']);
-        } else {
-            $this->app['logger.system']->error("Failed BoltSendEmailForNewContentExtension notification to {$emailTo}", ['event' => 'extensions']);
+        try {
+            $message->setTo($emailTo);
+
+            // Queue the message in the mailer
+            $this->app['mailer']->send($message);
+
+	    $this->app['logger.system']->info("Sent BoltSendEmailForNewContentExtension notification to {$emailTo}", ['event' => 'extensions']);
+        } catch (\Exception $e) {
+            $this->app['logger.system']->error(sprintf("BoltSendMailForNewContentExtension failed for address {$emailTo} - %s", $e->getMessage() ), ['event' => 'extensions']);
         }
     }
 

--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -146,7 +146,7 @@ class Notifications
         $html = $this->app['render']->render($this->subjectTpl, [
             'record' => $this->record
         ]);
-        $subject = new \Twig_Markup($html, 'UTF-8');
+        $subject = new \Twig_Markup($html->getContent(), 'UTF-8');
 
         /*
          * Body
@@ -155,8 +155,7 @@ class Notifications
             'record'    => $this->record,
             'recipient' => $recipient
         ]);
-        $body = new \Twig_Markup($html, 'UTF-8');
-
+        $body = new \Twig_Markup($html->getContent(), 'UTF-8');
 
         /*
          * Build email

--- a/src/Notifications.php
+++ b/src/Notifications.php
@@ -98,11 +98,12 @@ class Notifications
      * @param Silex\Application $app
      * @param \Bolt\Content     $record
      */
-    public function __construct(Silex\Application $app, array $config, Content $record)
+    public function __construct(Silex\Application $app, array $config, Content $record, $contenttype)
     {
         $this->app    = $app;
         $this->config = $config;
         $this->record = $record;
+	$this->contentType = $contenttype;
 
         $this->setVars();
     }
@@ -197,9 +198,6 @@ class Notifications
      */
     private function setVars()
     {
-        // Set ContentType from record
-        $this->contentType = $this->record->getContenttype();
-
         // Set Debug
         $this->debug         = $this->config['debug']['enabled'];
         $this->debug_address = $this->config['debug']['address'];


### PR DESCRIPTION
Bolt v3.3.3 throws the following exception when saving new entry:

> Uncaught Exception: ContextErrorException .
> 
> ContextErrorException in Notifications.php line 209: 
> Warning: Illegal offset type

`$this->contentType = $this->record->getContenttype();` returns now an array of type Bolt\Storage\Mapping\ContentType  (see [Bolt v3.3 API](https://docs.bolt.cm/api/bolt/bolt/3.3/Bolt/Storage/Entity/Content.html#method_getContenttype)) which can not be used as array key.

Use $contenttype variable defined in `hookPreSave()` and pass it to the Notifications class constructor.
